### PR TITLE
dx9 fixed build error (#2858)

### DIFF
--- a/Osiris/imgui/imgui_impl_dx9.cpp
+++ b/Osiris/imgui/imgui_impl_dx9.cpp
@@ -30,6 +30,7 @@
 #include <d3d9.h>
 #define DIRECTINPUT_VERSION 0x0800
 #include <dinput.h>
+#include <cstdint>
 
 // DirectX data
 static LPDIRECT3DDEVICE9        g_pd3dDevice = NULL;


### PR DESCRIPTION
imgui_impl_dx9.cpp(301,54): error C2039: "uint32_t": is not a member of "std"